### PR TITLE
add setPressed function

### DIFF
--- a/CreativeControls/Keyboard.qml
+++ b/CreativeControls/Keyboard.qml
@@ -131,6 +131,23 @@ Item
         { return v.key === a2[i].key; });
     }
 
+    function setPressed(key){
+        if(key !== undefined)
+        {
+            var newKeys = [ key ];
+            if(!sameKeys(newKeys, pressedKeys))
+            {
+                pressedKeys = newKeys;
+            }
+        }
+        else
+        {
+            pressedKeys = [ ];
+        }
+
+        canvas.requestPaint()
+    }
+
     Canvas
     {
         id: canvas


### PR DESCRIPTION
setting pressedKey directly doesn't work
we need to call canvas.requestPaint() to make it work
which seem to be 'private'